### PR TITLE
mousequake v0.0.3

### DIFF
--- a/Formula/mousequake.rb
+++ b/Formula/mousequake.rb
@@ -1,20 +1,20 @@
 class Mousequake < Formula
-  version "0.0.2"
+  version "0.0.3"
   desc "Simple tool for auto shaking mouse pointer"
   homepage "https://github.com/KanchiShimono/mousequake"
   license ""
 
   if OS.mac?
     if Hardware::CPU.intel?
-      url "https://github.com/KanchiShimono/mousequake/releases/download/v#{version}/mousequake-x86_64-apple-darwin.tar.gz.zip"
-      sha256 "80acd739b513d9e05d473d950351f9749016c8301ad20ebc14e90ac92322b48f"
+      url "https://github.com/KanchiShimono/mousequake/releases/download/v#{version}/mousequake-x86_64-apple-darwin.tar.gz"
+      sha256 "fc9f7db523958ddb385c999baba40a145f7e14af349eb3b7173d91e0cab5c6e1"
     elsif Hardware::CPU.arm?
-      url "https://github.com/KanchiShimono/mousequake/releases/download/v#{version}/mousequake-aarch64-apple-darwin.tar.gz.zip"
-      sha256 "308c52c6f68309ea64c9ee1ae4479d8a4679ff2fd82f665ff5e2454a178fb3b8"
+      url "https://github.com/KanchiShimono/mousequake/releases/download/v#{version}/mousequake-aarch64-apple-darwin.tar.gz"
+      sha256 "cebd4a781a5d16790171983133a6cc09adec5bd34a563e4bbc048142b6d961b5"
     end
   elsif OS.linux? && Hardware::CPU.intel?
-    url "https://github.com/KanchiShimono/mousequake/releases/download/v#{version}/mousequake-x86_64-unknown-linux-gnu.tar.gz.zip"
-    sha256 "8b8cf1612705a326e54c8ddac35fab82b0a88d8012b8be4c8e0519e23b198c6e"
+    url "https://github.com/KanchiShimono/mousequake/releases/download/v#{version}/mousequake-x86_64-unknown-linux-gnu.tar.gz"
+    sha256 "cf6760ef9e1b5ccadbd11a44473d343071fb450f4055dfd73b0347824bba9f11"
   end
 
   def install

--- a/Formula/mousequake.rb
+++ b/Formula/mousequake.rb
@@ -13,7 +13,7 @@ class Mousequake < Formula
       sha256 "cebd4a781a5d16790171983133a6cc09adec5bd34a563e4bbc048142b6d961b5"
     end
   elsif OS.linux? && Hardware::CPU.intel?
-    url "https://github.com/KanchiShimono/mousequake/releases/download/v#{version}/mousequake-x86_64-unknown-linux-gnu.tar.gz"
+    url "https://github.com/KanchiShimono/mousequake/releases/download/v#{version}/mousequake-x86_64-unknown-linux-musl.tar.gz"
     sha256 "cf6760ef9e1b5ccadbd11a44473d343071fb450f4055dfd73b0347824bba9f11"
   end
 


### PR DESCRIPTION
- **mousequake v0.0.3**
- **Change Linux binary to use musl**
